### PR TITLE
fix(plugin): handled circular json

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var _ = require('lodash');
 var uuid = require('uuid');
 var moment = require('moment');
 var path = require('path');
-var dereferenceJSON = require('extendr').dereferenceJSON;
-var imageToAscii = require("image-to-ascii")
+var imageToAscii = require("image-to-ascii");
+var CircularJSON = require('circular-json');
 
 /**
  * This plugin does few things:
@@ -212,7 +212,7 @@ protractorUtil.writeReport = function(context) {
         generatedOn: new Date()
     };
 
-    fse.outputFile(file, JSON.stringify(dereferenceJSON(data)), function(err) {
+    fse.outputFile(file, CircularJSON.stringify(data), function(err) {
         if (err) protractorUtil.logDebug(err);
         protractorUtil.joinReports(context);
     });

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/azachar/protractor-screenshoter-plugin",
   "dependencies": {
-    "extendr": "^3.2.2",
+    "circular-json": "^0.3.1",
     "fs-extra": "^1.0.0",
     "image-to-ascii": "^3.0.5",
     "lodash": "^4.16.4",


### PR DESCRIPTION
Fixes issue where report generation was not possible because of the following error:

`TypeError: Converting circular structure to JSON`

