### PR TITLE
Feature- Allow users to add custom logs

### DIFF
--- a/spec/integrational/protractor/angularjs-homepage-test.js
+++ b/spec/integrational/protractor/angularjs-homepage-test.js
@@ -1,4 +1,5 @@
 /*The MIT License, Copyright (c) 2010-2016 Google, Inc.*/
+var reporter = require('../../../index.js');
 
 describe('angularjs homepage', function() {
   it('should greet the named user', function() {
@@ -21,6 +22,7 @@ describe('angularjs homepage', function() {
     });
 
     it('should list todos', function() {
+      reporter.log('Listing todos');
       expect(todoList.count()).toEqual(2);
       expect(todoList.get(1).getText()).toEqual('build an AngularJS app');
     });
@@ -28,6 +30,7 @@ describe('angularjs homepage', function() {
     it('should add a todo', function() {
       var addTodo = element(by.model('todoList.todoText'));
       var addButton = element(by.css('[value="add"]'));
+      reporter.log('Added todos');
 
       addTodo.sendKeys('write a protractor test');
       addButton.click();

--- a/spec/integrational/screenshoter.int.spec.js
+++ b/spec/integrational/screenshoter.int.spec.js
@@ -3,6 +3,7 @@ var path = require('path');
 
 var fs = require('fs-extra');
 var cp = require('child_process');
+var _ = require('lodash');
 
 function runProtractorWithConfig(configName) {
     var command = 'protractor ./spec/integrational/protractor-config/' + configName;
@@ -126,6 +127,9 @@ describe("Screenshoter running under protractor", function() {
                 expect(report.tests[2].passedExpectations[1].screenshots[0].browser).toBeDefined();
                 expect(report.tests[2].passedExpectations[1].screenshots[0].when).toBeDefined();
 
+                expect(report.userLogs).toBeDefined();
+                expect(_.includes((report.userLogs), 'Added todos')).toEqual(true);
+                expect(_.includes((report.userLogs), 'Listing todos')).toEqual(true);
                 done();
             });
         });

--- a/spec/unit/screenshoter.unit.spec.js
+++ b/spec/unit/screenshoter.unit.spec.js
@@ -1,4 +1,6 @@
 var fse = require('fs-extra');
+var fs = require('fs');
+var _ = require('lodash');
 
 describe("Screenshoter unit", function() {
 
@@ -130,5 +132,17 @@ describe("Screenshoter unit", function() {
         });
     });
 
-
+    it("should write user logs", function () {
+        screenshoter.config = {
+            screenshotPath: 'REPORTS',
+        };
+        screenshoter.setup();
+        screenshoter.log('test');
+        var logs = fs.readFileSync(screenshoter.config.screenshotPath + '/logs' + '/log.txt', 'utf-8');
+        expect(_.includes(logs, 'test')).toEqual(true);
+        screenshoter.log('check');
+        logs = fs.readFileSync(screenshoter.config.screenshotPath + '/logs' + '/log.txt', 'utf-8');
+        expect(_.includes(logs, 'test')).toEqual(true);
+        expect(_.includes(logs, 'check')).toEqual(true);
+    });
 });


### PR DESCRIPTION
These changes can allow user to add logs to the created `index.js` which can be used by the html reporter to visualize the logs.

## **Usage:**
```
var reporter = require('protractor-screenshoter-plugin');
reporter.log('Action completed');
```

## **Major Changes:**

**`index.js`**: Added a `log` method which could allow users to log and store the log in a textfile. Added a `userLogs` parameter to the `data` created which gets added in `index.js`. The `userLogs` stores the logs from the log file in a string format.

**`screenshoter.unit.spec.js`**: Added a test to check for log file being created with the logs added by the user.

**`angularjs-homepage-test.js`**: Added two calls to the log method from the module to log certain events.

**`screenshoter.int.spec.js`**: Extended an int test to also check for the logs being added to the `index.js` when used in `angularjs-homepage-test.js`.

## **Review and Reporter:**

I would request you to please review all my changes constructively and let me know if any modification is required. This is a PR to the master branch currently, let me know if you want it to be in a different branch.

I would also request you (or anyone who could use this feature) to update the html reporter so that the user logs can be visualized.

Thank you! Please let me know if you have any questions or concerns.
