### PR TITLE
fix(package): move image-to-ascii to optionalDependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,17 @@ var _ = require('lodash');
 var uuid = require('uuid');
 var moment = require('moment');
 var path = require('path');
-var imageToAscii = require("image-to-ascii");
 var CircularJSON = require('circular-json');
 var q = require('q');
 var assert = require('assert');
+
+try {  // optional dependency, ignore if not installed
+    var imageToAscii = require("image-to-ascii");
+} catch(e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+        throw e;
+    }
+}
 
 /**
  * This plugin does few things:
@@ -141,6 +148,9 @@ protractorUtil.takeScreenshotOnExpectDone = function(context) {
                 });
                 if (makeAsciiLog && !browserInstance.skipImageToAscii) {
                     try {
+                        if (!imageToAscii) {
+                            throw new Error('image-to-ascii is not installed');
+                        }
                         imageToAscii(finalFile, context.config.imageToAsciiOpts, function(err, converted) {
                             var asciImage;
                             asciImage += '\n\n============================\n';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "circular-json": "^0.3.1",
     "fs-extra": "^1.0.0",
-    "image-to-ascii": "^3.0.5",
     "lodash": "^4.17.3",
     "mkdirp": "^0.5.1",
     "moment": "^2.18.1",
@@ -55,6 +54,9 @@
     "jasmine": "^2.5.2",
     "protractor": "^5.x",
     "standard-version": "^4.0.0"
+  },
+  "optionalDependencies": {
+    "image-to-ascii": "^3.0.5"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
this change allows to install and use protractor-screenshoter-plugin even if image-to-ascii cannot
be installed successfully (due to lwip2 compilation error)

resolves #42