### PR TITLE
Add `suites` parameter to failTestOnErrorLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ exports.config = {
        failTestOnErrorLog: {
                 failTestOnErrorLogLevel: {Number},  (Default - 900)
                 excludeKeywords: {A JSON Array}
+                suites: {A JSON Array}
            }
        }],
        onPrepare: function () {
@@ -295,6 +296,12 @@ Default: 900
 An array of keywords to be excluded, while searching for error logs. i.e If a log contains any of these keywords, spec/test will not be marked failed.
 
 Please do not specify this flag, if you don't supply any such keywords.
+
+### suites
+
+An array of `suites` (protractor.config.suites) where the failTestOnErrorLog will run.
+
+Please do not specify this flag, if you want all your tests to run through this failTestOnErrorLog validation.
 
 # Development
 

--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ protractorUtil.failTestOnErrorLog = function(context) {
       /*
        * Verifies if the `suite` where tests are running is present on the `failTestOnErrorLog.suites` list
       */
-      function isAValidSuite() {
+      function isASuiteToCheck() {
         //If there are no suites defined the default value is 'ALL'
         if(!context.config.failTestOnErrorLog.suites) {
           return true;
@@ -428,7 +428,7 @@ protractorUtil.failTestOnErrorLog = function(context) {
           browserLogs.forEach(function(log) {
             var logLevel = context.config.failTestOnErrorLog.failTestOnErrorLogLevel ? context.config.failTestOnErrorLog.failTestOnErrorLogLevel : 900;
             var flag = false;
-            if ((log.level.value > logLevel) && isAValidSuite()) { // it's an error log && is a valid suite
+            if ((log.level.value > logLevel) && isASuiteToCheck()) { // it's an error log && is a valid suite
               if (context.config.failTestOnErrorLog.excludeKeywords) {
                 context.config.failTestOnErrorLog.excludeKeywords.forEach(function(keyword) {
                   if (log.message.search(keyword) > -1) {

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var assert = require('assert');
  *      failTestOnErrorLog: {
  *               failTestOnErrorLogLevel: {Number},  (Default - 900)
  *               excludeKeywords: {A JSON Array}
+ *               suites: {A JSON Array}
  *          }
  *       }]
  *    };
@@ -388,6 +389,19 @@ protractorUtil.failTestOnErrorLog = function(context) {
         });
 
         afterEach(function() {
+
+            /*
+             * Verifies if the `suite` where tests are running is present on the `failTestOnErrorLog.suites` list
+             */
+            function isAValidSuite() {
+                //If there are no suites defined the default value is 'ALL'
+                if(!context.config.failTestOnErrorLog.suites) {
+                    return true;
+                }
+
+                return (context.config.failTestOnErrorLog.suites.indexOf(browser.getProcessedConfig().value_.suite) > -1);
+            }
+
             /*
              * Verifies that console has no error logs, if error log is there test is marked as failure
              */
@@ -398,7 +412,7 @@ protractorUtil.failTestOnErrorLog = function(context) {
                     browserLogs.forEach(function(log) {
                         var logLevel = context.config.failTestOnErrorLog.failTestOnErrorLogLevel ? context.config.failTestOnErrorLog.failTestOnErrorLogLevel : 900;
                         var flag = false;
-                        if (log.level.value > logLevel) { // it's an error log
+                        if ((log.level.value > logLevel) && isAValidSuite()) { // it's an error log && is a valid suite
                             if (context.config.failTestOnErrorLog.excludeKeywords) {
                                 context.config.failTestOnErrorLog.excludeKeywords.forEach(function(keyword) {
                                     if (log.message.search(keyword) > -1) {

--- a/spec/integrational/protractor-config/suitesConsoleErrors.js
+++ b/spec/integrational/protractor-config/suitesConsoleErrors.js
@@ -1,0 +1,21 @@
+var env = require('../environment');
+
+exports.config = {
+    seleniumAddress: env.seleniumAddress,
+    framework: 'jasmine2',
+    suites: {
+        homepage: '../protractor/angularjs-homepage-test.js',
+        console: '../protractor/console-error-test.js',
+    },
+    specs: ['../protractor/*.js'],
+    plugins: [{
+        path: '../../../index.js',
+        screenshotPath: '.tmp/suitesConsoleErrors',
+        failTestOnErrorLog: {
+            failTestOnErrorLogLevel: 999, // all errors
+            suites: [
+                "console"
+            ]
+        }
+    }]
+};

--- a/spec/integrational/protractor-config/suitesHomepage.js
+++ b/spec/integrational/protractor-config/suitesHomepage.js
@@ -1,0 +1,21 @@
+var env = require('../environment');
+
+exports.config = {
+    seleniumAddress: env.seleniumAddress,
+    framework: 'jasmine2',
+    suites: {
+        homepage: '../protractor/angularjs-homepage-test.js',
+        console: '../protractor/console-error-test.js',
+    },
+    specs: ['../protractor/*.js'],
+    plugins: [{
+        path: '../../../index.js',
+        screenshotPath: '.tmp/suitesHomepage',
+        failTestOnErrorLog: {
+            failTestOnErrorLogLevel: 999, // all errors
+            suites: [
+                "homepage"
+            ]
+        }
+    }]
+};

--- a/spec/integrational/screenshoter.int.spec.js
+++ b/spec/integrational/screenshoter.int.spec.js
@@ -923,7 +923,7 @@ describe("Screenshoter running under protractor", function() {
 
   describe("Suite(s) configuration ", function() {
 
-    it("should fail if the console-error suite is specified in 'suites'", function() {
+    it("should fail if the console-error suite is specified in 'suites'", function(done) {
       runProtractorWithConfig('suitesConsoleErrors.js', '--suite console');
 
       fs.readFile('.tmp/suitesConsoleErrors/report.js', 'utf8', function(err, data) {
@@ -935,10 +935,11 @@ describe("Screenshoter running under protractor", function() {
         var report = getReportAsJson(data);
         expect(report.tests[0].failedExpectations.length).toBe(1); //Console-error
         expect(report.tests[1].failedExpectations.length).toBe(1); //Console-error
+        done();
       });
     });
 
-    it("should pass if the console-error suite is not specified in 'suites'", function() {
+    it("should pass if the console-error suite is not specified in 'suites'", function(done) {
       runProtractorWithConfig('suitesHomepage.js', '--suite console');
       
       fs.readFile('.tmp/suitesHomepage/report.js', 'utf8', function(err, data) {
@@ -950,6 +951,7 @@ describe("Screenshoter running under protractor", function() {
         var report = getReportAsJson(data);
         expect(report.tests[0].failedExpectations.length).toBe(0);
         expect(report.tests[1].failedExpectations.length).toBe(0);
+        done();
       });
     });
   });

--- a/spec/integrational/screenshoter.int.spec.js
+++ b/spec/integrational/screenshoter.int.spec.js
@@ -6,12 +6,15 @@ var cp = require('child_process');
 
 function runProtractorWithConfig(configName, params) {
   var command;
-  params = params ? ' ' + params : '';
   if (env.coverage) {
-    command = 'istanbul cover --print none --report lcovonly --dir coverage/' + configName + ' node_modules/protractor/bin/protractor ./spec/integrational/protractor-config/' + configName + params;
+    command = 'istanbul cover --print none --report lcovonly --dir coverage/' + configName + ' | node_modules/protractor/bin/protractor ./spec/integrational/protractor-config/' + configName;
   } else {
-    command = 'node_modules/protractor/bin/protractor ./spec/integrational/protractor-config/' + configName + params;
+    command = 'node_modules/protractor/bin/protractor ./spec/integrational/protractor-config/' + configName;
   }
+
+  params = params ? ' ' + params : '';
+  command += params;
+
   console.info('Running command ' + command);
   try {
     cp.execSync(command, {
@@ -921,10 +924,10 @@ describe("Screenshoter running under protractor", function() {
     });
   });
 
-  describe("Suite(s) configuration ", function() {
+  describe("suitesConsoleErrors", function() {
 
     it("should fail if the console-error suite is specified in 'suites'", function(done) {
-      runProtractorWithConfig('suitesConsoleErrors.js', '--suite console');
+      runProtractorWithConfig('suitesConsoleErrors.js', '--suite=\"console\"');
 
       fs.readFile('.tmp/suitesConsoleErrors/report.js', 'utf8', function(err, data) {
         if (err) {
@@ -938,9 +941,12 @@ describe("Screenshoter running under protractor", function() {
         done();
       });
     });
+  });
 
+  describe("suitesHomepage", function() {
+      
     it("should pass if the console-error suite is not specified in 'suites'", function(done) {
-      runProtractorWithConfig('suitesHomepage.js', '--suite console');
+      runProtractorWithConfig('suitesHomepage.js', '--suite=console');
       
       fs.readFile('.tmp/suitesHomepage/report.js', 'utf8', function(err, data) {
         if (err) {


### PR DESCRIPTION
**Motivation:** Some `suites`, like the ones with mocked data we don't want the tests to fail because of browser's console errors.

**Changes:** This merge-requests adds the ability to specify which `suites` (protractor.config.suites) do we want to failTestOnErrorLog.
