### PR TITLE
feat: 🎸 Add an option to inject HTML to <head> content

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ exports.config = {
        dumpOnExpect: {String}    (Default - 'failure', 'failure+success', 'none'),
        dumpOnSpec: {String}    (Default - 'none', 'failure+success', 'failure'),
        dump: {Function} (Default - null),
+       reportOptions: {
+           injectToHead: {String} (Default - null)
+       },
        onPrepare: function () {
         // returning the promise makes protractor wait for the reporter config before executing tests
         return global.browser.getProcessedConfig().then(function (config) {
@@ -475,6 +478,12 @@ Please do not specify this flag, if you don't supply any such keywords.
 An array of `suites` (protractor.config.suites) where the failTestOnErrorLog will run.
 
 Please do not specify this flag, if you want all your tests to run through this failTestOnErrorLog validation.
+
+### injectToHead
+
+HTML source to appended into `<head>` section of the report page.
+
+For example, you can use this to load CSS from CDN.
 
 # Development
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var mkdirp = require('mkdirp');
 var _ = require('lodash');
 var uuid = require('uuid');
 var moment = require('moment');
-var path = require('path');
 var CircularJSON = require('circular-json');
 var q = require('q');
 var assert = require('assert');
@@ -416,8 +415,8 @@ protractorUtil.installReporter = function(context) {
   var dest = context.config.screenshotPath + '/';
   protractorUtil.logInfo('Creating reporter at ' + dest);
   try {
-    var src = path.join(require.resolve('screenshoter-report-analyzer/dist/index.html'), '../');
-    fse.copy(src, dest);
+    var analyzer = require('screenshoter-report-analyzer');
+    analyzer.setup(dest, context.config.reportOptions);
   } catch (err) {
     console.error(err);
     return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,16 +250,6 @@
       "integrity": "sha512-ikB0JHv6vCR1KYUQAzTO4gi/lXLElT4Tx+6De2pc/OZwizE9LRNiTa+U8TBFKBD/nntPnr/MPSHSnOTybjhqNA==",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -463,6 +453,12 @@
         }
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -568,6 +564,20 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.1",
+        "entities": "1.1.2",
+        "htmlparser2": "3.10.1",
+        "lodash": "4.17.11",
+        "parse5": "3.0.3"
+      }
     },
     "circular-json": {
       "version": "0.5.1",
@@ -1021,8 +1031,8 @@
       "integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.2",
         "lodash": "4.17.11",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -1077,6 +1087,24 @@
           "dev": true
         }
       }
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.3",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.2"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -1179,6 +1207,41 @@
         "esutils": "2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.1",
+        "entities": "1.1.2"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.1",
+        "domelementtype": "1.3.1"
+      }
+    },
     "dot-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
@@ -1197,6 +1260,12 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
@@ -1782,6 +1851,48 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.1",
+        "domhandler": "2.4.2",
+        "domutils": "1.5.1",
+        "entities": "1.1.2",
+        "inherits": "2.0.3",
+        "readable-stream": "3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "string_decoder": "1.3.0",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.2.0"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2205,6 +2316,16 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2530,6 +2651,15 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
       }
     },
     "null-check": {
@@ -3796,6 +3926,15 @@
         "error-ex": "1.3.1"
       }
     },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.117"
+      }
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -4428,6 +4567,12 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4460,12 +4605,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "codecov": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "eslint": "^5.6.0",

--- a/spec/integrational/protractor-config/injectToHead.js
+++ b/spec/integrational/protractor-config/injectToHead.js
@@ -1,0 +1,14 @@
+var env = require('../environment');
+
+exports.config = {
+  seleniumAddress: env.seleniumAddress,
+  framework: 'jasmine2',
+  specs: ['../protractor/angularjs-homepage-test.js'],
+  plugins: [{
+    path: '../../../index.js',
+    screenshotPath: '.tmp/injectToHead',
+    reportOptions: {
+      injectToHead: '<link id="injected-to-head" rel="stylesheet" href="/path/to/somewhere">'
+    }
+  }]
+};

--- a/spec/integrational/screenshoter.int.spec.js
+++ b/spec/integrational/screenshoter.int.spec.js
@@ -1554,4 +1554,26 @@ describe("Screenshoter running under protractor", function() {
 
     });
   });
+
+  describe("Should support injectToHead", function() {
+    beforeAll(function() {
+      runProtractorWithConfig('injectToHead.js');
+    });
+
+    it("injected element should exist", function(done) {
+      fs.readFile('.tmp/injectToHead/index.html', 'utf8', function(err, data) {
+        if (err) {
+          return done.fail(err);
+        }
+
+        var cheerio = require('cheerio');
+        var $ = cheerio.load(data);
+
+        expect($('head #injected-to-head').length).toEqual(1);
+
+        done();
+      });
+
+    });
+  });
 });


### PR DESCRIPTION
NOTE: This request depends on azachar/screenshoter-report-analyzer#5 and don't work without that update.

Our CI server generates test reports with that plugin and they’re shared among our development teams.

But unfortunately web font icons aren’t displayed on those reports as those reports are placed in the authenticated area and web fonts are always accessed with “anonymous” mode [1] and blocked in this case.

I want to inject a `<link>` tag into the report, which imports css and web fonts from CDN, like ones provided by bootstrap [2] .

This request passes options to `screenshoter-report-analyzer` and allow us to inject HTMLs into the `<head>` content.

Before this change, icons are not shown:
![Screenshot_2020-02-23-Screenshot-reporter](https://user-images.githubusercontent.com/3115961/75106692-8ff1e580-5662-11ea-8dcb-94e8d7476285.png)

With this change and following configuration, icons are shown:
```
  plugins: [
    {
      package: 'protractor-screenshoter-plugin',
      screenshotPath: './screenshoter',
      reportOptions: {
        injectToHead: '<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">'
      }
    }
  ]
```

![Screenshot_2020-02-23-Screenshot-reporter(1)](https://user-images.githubusercontent.com/3115961/75106724-ba43a300-5662-11ea-8e56-8edc12442e1e.png)

[1] https://www.w3.org/TR/css-fonts-3/#font-fetching-requirements
[2] https://www.bootstrapcdn.com/fontawesome/

